### PR TITLE
Implement empty

### DIFF
--- a/Puppet/Stdlib.hs
+++ b/Puppet/Stdlib.hs
@@ -306,5 +306,5 @@ validateString [] = throwPosError "validate_string(): wrong number of arguments,
 validateString x = mapM_ resolvePValueString x >> return PUndef
 
 pvalues :: PValue -> InterpreterMonad PValue
-pvalues (PHash h) = return $ PArray (V.fromList (h ^.. traverse)) -- 
+pvalues (PHash h) = return $ PArray (V.fromList (h ^.. traverse))
 pvalues x = throwPosError ("values(): expected a hash, not" <+> pretty x)


### PR DESCRIPTION
Hi,

I have implemented `empty` which was missing. I had to use `_empty` to avoid a naming space clash with 

```
imported from ‘Puppet.PP’ at Puppet/Stdlib.hs:4:1-16
                             (and originally defined in ‘Text.PrettyPrint.ANSI.Leijen’)
```

As a note I only need to do:

```
  $classes = hiera('classes')
  if empty($::role) {
    $catalog_role = $classes
  } else {
    $catalog_role = flatten([$::role, $classes])
  }
```

Maybe you know a better way to do this ?
