### PR TITLE
Implement is_bool

### DIFF
--- a/Puppet/Stdlib.hs
+++ b/Puppet/Stdlib.hs
@@ -234,8 +234,7 @@ isString pv = return $ PBoolean $ case (pv ^? _PString, pv ^? _Number) of
                                      _           -> False
 
 isBool :: PValue -> InterpreterMonad PValue
-isBool (PBoolean _) = return $ PBoolean True
-isBool _ = return $ PBoolean False
+isBool = return . PBoolean . has _PBoolean
 
 keys :: PValue -> InterpreterMonad PValue
 keys (PHash h) = return (PArray $ V.fromList $ map PString $ HM.keys h)


### PR DESCRIPTION
Thanks to review this code.
It might be wrong as I actually don't understand the implementation of `isString` ...

```
isString pv = return $ PBoolean $ case (pv ^? _PString, pv ^? _Number) of
                                     (_, Just _) -> False
                                     (Just _, _) -> True
                                     _           -> False
```

Why do we need to `case` for `(_, Just _) -> False` ?
