### PR TITLE
Refactoring optparse code to be more adhoc

### DIFF
--- a/Puppet/Preferences.hs
+++ b/Puppet/Preferences.hs
@@ -52,6 +52,7 @@ genPreferences basedir = do
     return $ Preferences manifestdir modulesdir templatedir dummyPuppetDB (baseNativeTypes `HM.union` loadedTypes) (stdlibFunctions) (Just (basedir <> "/hiera.yaml")) mempty
 
 -- | Setup preferences from external/custom params
+-- k is set through lenses (ie: hieraPath.~mypath)
 setupPreferences :: FilePath -> (Preferences IO -> Preferences IO) -> IO (Preferences IO)
 setupPreferences basedir k =
   -- use lens composition


### PR DESCRIPTION
Thanks for reviewing this PR. I believe it increases the overall readability (mimicking the `optparse-applicative` tutorial)

Important note: I am not sure why the exit code was `3`. I suppose the optparse default is good enough but didn't check. Anyhow this PR has removed the explicit setting to `3`, I hope it is alright.

If you accept it, I will modify `pdbQuery` tomorrow for consistency sake 
