### PR TITLE
Throw an error when parsing hiera fails instead of creating a dummyHiera

### DIFF
--- a/Puppet/Daemon.hs
+++ b/Puppet/Daemon.hs
@@ -86,9 +86,9 @@ initDaemon prefs = do
     intr          <- startRubyInterpreter
     getTemplate   <- initTemplateDaemon intr prefs templateStats
     hquery        <- case prefs ^. hieraPath of
-                         Just p -> startHiera p >>= \case
-                            Left _ -> return dummyHiera
-                            Right x -> return x
+                         Just p  -> startHiera p >>= \case
+                            Left err -> error err
+                            Right x  -> return x
                          Nothing -> return dummyHiera
     luacontainer <- initLuaMaster (T.pack (prefs ^. modulesPath))
     let myprefs = prefs & prefExtFuncs %~ HM.union luacontainer


### PR DESCRIPTION
I guess it is still ok if I use a PR when I need a confirmation for a change.

Does it make more sense to throw an error when the parsing of the hiera file fails ?
