### PR TITLE
Rename "PuppetTypeMethods" into "NativeTypeMethods"

### DIFF
--- a/Puppet/Interpreter.hs
+++ b/Puppet/Interpreter.hs
@@ -57,7 +57,7 @@ getCatalog :: Monad m
            -> PuppetDBAPI m
            -> T.Text -- ^ Node name
            -> Facts -- ^ Facts ...
-           -> Container PuppetTypeMethods -- ^ List of native types
+           -> Container NativeTypeMethods -- ^ List of native types
            -> Container ( [PValue] -> InterpreterMonad PValue )
            -> HieraQueryFunc m -- ^ Hiera query function
            -> ImpureMethods m

--- a/Puppet/NativeTypes.hs
+++ b/Puppet/NativeTypes.hs
@@ -22,14 +22,14 @@ import           Puppet.NativeTypes.SshSecure
 import           Puppet.NativeTypes.User
 import           Puppet.NativeTypes.ZoneRecord
 
-fakeTypes :: [(PuppetTypeName, PuppetTypeMethods)]
+fakeTypes :: [(NativeTypeName, NativeTypeMethods)]
 fakeTypes = map faketype ["class"]
 
-defaultTypes :: [(PuppetTypeName, PuppetTypeMethods)]
+defaultTypes :: [(NativeTypeName, NativeTypeMethods)]
 defaultTypes = map defaulttype ["augeas","computer","filebucket","interface","k5login","macauthorization","mailalias","maillist","mcx","nagios_command","nagios_contact","nagios_contactgroup","nagios_host","nagios_hostdependency","nagios_hostescalation","nagios_hostextinfo","nagios_hostgroup","nagios_service","nagios_servicedependency","nagios_serviceescalation","nagios_serviceextinfo","nagios_servicegroup","nagios_timeperiod","notify","package","resources","router","schedule","scheduledtask","selboolean","selmodule","service","ssh_authorized_key","sshkey","stage","tidy","vlan","yumrepo","zfs","zone","zpool"]
 
 -- | The map of native types. They are described in "Puppet.NativeTypes.Helpers".
-baseNativeTypes :: Container PuppetTypeMethods
+baseNativeTypes :: Container NativeTypeMethods
 baseNativeTypes = HM.fromList
     ( nativeHost
     : nativeMount

--- a/Puppet/NativeTypes/Concat.hs
+++ b/Puppet/NativeTypes/Concat.hs
@@ -7,13 +7,13 @@ import Puppet.NativeTypes.Helpers
 import Puppet.Interpreter.Types
 import qualified Data.Text as T
 
-nativeConcat :: (PuppetTypeName, PuppetTypeMethods)
+nativeConcat :: (NativeTypeName, NativeTypeMethods)
 nativeConcat = ("concat", ptypemethods concatparamfunctions return)
 
-nativeConcatFragment :: (PuppetTypeName, PuppetTypeMethods)
+nativeConcatFragment :: (NativeTypeName, NativeTypeMethods)
 nativeConcatFragment = ("concat::fragment", ptypemethods fragmentparamfunctions validateSourceOrContent)
 
-concatparamfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+concatparamfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 concatparamfunctions =
     [("name"                , [nameval])
     ,("ensure"              , [defaultvalue "present", string, values ["present","absent"]])
@@ -31,7 +31,7 @@ concatparamfunctions =
     -- ,("gnu"                 , [string])
     ]
 
-fragmentparamfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+fragmentparamfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 fragmentparamfunctions =
     [("name"                , [nameval])
     ,("target"              , [string, mandatory])

--- a/Puppet/NativeTypes/Exec.hs
+++ b/Puppet/NativeTypes/Exec.hs
@@ -5,11 +5,11 @@ import Puppet.Interpreter.Types
 import qualified Data.Text as T
 import Control.Lens
 
-nativeExec :: (PuppetTypeName, PuppetTypeMethods)
+nativeExec :: (NativeTypeName, NativeTypeMethods)
 nativeExec = ("exec", ptypemethods parameterfunctions fullyQualifiedOrPath)
 
 -- Autorequires: If Puppet is managing the user or group that owns a file, the file resource will autorequire them. If Puppet is managing any parent directories of a file, the file resource will autorequire them.
-parameterfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+parameterfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 parameterfunctions =
     [("command"     , [nameval])
     ,("creates"     , [rarray, strings, fullyQualifieds])
@@ -30,7 +30,7 @@ parameterfunctions =
     ,("user"        , [string])
     ]
 
-fullyQualifiedOrPath :: PuppetTypeValidate
+fullyQualifiedOrPath :: NativeTypeValidate
 fullyQualifiedOrPath res = case (res ^. rattributes . at "path", res ^. rattributes . at "command") of
                                (Nothing, Just (PString x)) -> if T.head x == '/'
                                                                        then Right res

--- a/Puppet/NativeTypes/File.hs
+++ b/Puppet/NativeTypes/File.hs
@@ -7,13 +7,13 @@ import Data.Char (isDigit)
 import qualified Data.Text as T
 import Control.Lens
 
-nativeFile :: (PuppetTypeName, PuppetTypeMethods)
+nativeFile :: (NativeTypeName, NativeTypeMethods)
 nativeFile = ("file", ptypemethods parameterfunctions (validateSourceOrContent >=> validateMode))
 
 
 -- Autorequires: If Puppet is managing the user or group that owns a file, the file resource will autorequire them. If Puppet is managing any parent directories of a file, the file resource will autorequire them.
 
-parameterfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+parameterfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 parameterfunctions =
     [("backup"      , [string])
     ,("checksum"    , [values ["md5", "md5lite", "mtime", "ctime", "none"]])
@@ -37,7 +37,7 @@ parameterfunctions =
     ,("source"      , [rarray, strings, flip runarray checkSource])
     ]
 
-validateMode :: PuppetTypeValidate
+validateMode :: NativeTypeValidate
 validateMode res = do
     modestr <- case res ^. rattributes . at "mode" of
                   Just (PString s) -> return s
@@ -50,7 +50,7 @@ validateMode res = do
         else return res
 
 
-checkSource :: T.Text -> PValue -> PuppetTypeValidate
+checkSource :: T.Text -> PValue -> NativeTypeValidate
 checkSource _ (PString x) res | "puppet://" `T.isPrefixOf` x = Right res
                               | "file://" `T.isPrefixOf` x = Right res
                               | otherwise = throwError "A source should start with either puppet:// or file://"

--- a/Puppet/NativeTypes/Group.hs
+++ b/Puppet/NativeTypes/Group.hs
@@ -4,11 +4,11 @@ import Puppet.NativeTypes.Helpers
 import Puppet.Interpreter.Types
 import qualified Data.Text as T
 
-nativeGroup :: (PuppetTypeName, PuppetTypeMethods)
+nativeGroup :: (NativeTypeName, NativeTypeMethods)
 nativeGroup = ("group", ptypemethods parameterfunctions return)
 
 -- Autorequires: If Puppet is managing the user or group that owns a file, the file resource will autorequire them. If Puppet is managing any parent directories of a file, the file resource will autorequire them.
-parameterfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+parameterfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 parameterfunctions =
     [("allowdupe"               , [string, defaultvalue "false", values ["true","false"]])
     ,("attribute_membership"    , [string, defaultvalue "minimum", values ["inclusive","minimum"]])

--- a/Puppet/NativeTypes/Helpers.hs
+++ b/Puppet/NativeTypes/Helpers.hs
@@ -17,7 +17,7 @@ module Puppet.NativeTypes.Helpers
     , concattype
     , nameval
     , defaultValidate
-    , PuppetTypeName
+    , NativeTypeName
     , parameterFunctions
     , integer
     , integers
@@ -46,7 +46,7 @@ import qualified Data.Vector as V
 import Data.Aeson.Lens (_Number,_Integer)
 import Data.Maybe (fromMaybe)
 
-type PuppetTypeName = T.Text
+type NativeTypeName = T.Text
 
 paramname :: T.Text -> Doc
 paramname = red . ttext
@@ -55,30 +55,30 @@ paramname = red . ttext
 perror :: Doc -> Either PrettyError Resource
 perror = Left . PrettyError
 
-ptypemethods :: [(T.Text, [T.Text -> PuppetTypeValidate])] -> PuppetTypeValidate -> PuppetTypeMethods
+ptypemethods :: [(T.Text, [T.Text -> NativeTypeValidate])] -> NativeTypeValidate -> NativeTypeMethods
 ptypemethods def extraV =
   let params = fromKeys def
-  in PuppetTypeMethods (defaultValidate params >=> parameterFunctions def >=> extraV)  params
+  in NativeTypeMethods (defaultValidate params >=> parameterFunctions def >=> extraV)  params
   where
     fromKeys = HS.fromList . map fst
 
-faketype :: PuppetTypeName -> (PuppetTypeName, PuppetTypeMethods)
-faketype tname = (tname, PuppetTypeMethods Right HS.empty)
+faketype :: NativeTypeName -> (NativeTypeName, NativeTypeMethods)
+faketype tname = (tname, NativeTypeMethods Right HS.empty)
 
-concattype :: PuppetTypeName -> (PuppetTypeName, PuppetTypeMethods)
-concattype tname = (tname, PuppetTypeMethods (defaultValidate HS.empty) HS.empty)
+concattype :: NativeTypeName -> (NativeTypeName, NativeTypeMethods)
+concattype tname = (tname, NativeTypeMethods (defaultValidate HS.empty) HS.empty)
 
-defaulttype :: PuppetTypeName -> (PuppetTypeName, PuppetTypeMethods)
-defaulttype tname = (tname, PuppetTypeMethods (defaultValidate HS.empty) HS.empty)
+defaulttype :: NativeTypeName -> (NativeTypeName, NativeTypeMethods)
+defaulttype tname = (tname, NativeTypeMethods (defaultValidate HS.empty) HS.empty)
 
 {-| Validate resources given a list of valid parameters:
 
       * checks that no unknown parameters have been set (except metaparameters)
 -}
-defaultValidate :: HS.HashSet T.Text -> PuppetTypeValidate
+defaultValidate :: HS.HashSet T.Text -> NativeTypeValidate
 defaultValidate validparameters = checkParameterList validparameters >=> addDefaults
 
-checkParameterList :: HS.HashSet T.Text -> PuppetTypeValidate
+checkParameterList :: HS.HashSet T.Text -> NativeTypeValidate
 checkParameterList validparameters res | HS.null validparameters = Right res
                                        | otherwise = if HS.null setdiff
                                             then Right res
@@ -88,7 +88,7 @@ checkParameterList validparameters res | HS.null validparameters = Right res
         setdiff = HS.difference keyset (metaparameters `HS.union` validparameters)
 
 -- | This validator always accept the resources, but add the default parameters (to be defined :)
-addDefaults :: PuppetTypeValidate
+addDefaults :: NativeTypeValidate
 addDefaults res = Right (res & rattributes %~ newparams)
     where
         def PUndef = False
@@ -97,7 +97,7 @@ addDefaults res = Right (res & rattributes %~ newparams)
         defaults    = HM.empty
 
 -- | Helper function that runs a validor on a PArray
-runarray :: T.Text -> (T.Text -> PValue -> PuppetTypeValidate) -> PuppetTypeValidate
+runarray :: T.Text -> (T.Text -> PValue -> NativeTypeValidate) -> NativeTypeValidate
 runarray param func res = case res ^. rattributes . at param of
     Just (PArray x) -> V.foldM (flip (func param)) res x
     Just x          -> perror $ "Parameter" <+> paramname param <+> "should be an array, not" <+> pretty x
@@ -106,15 +106,15 @@ runarray param func res = case res ^. rattributes . at param of
 {-| This checks that a given parameter is a string. If it is a 'ResolvedInt' or
 'ResolvedBool' it will convert them to strings.
 -}
-string :: T.Text -> PuppetTypeValidate
+string :: T.Text -> NativeTypeValidate
 string param res = case res ^. rattributes . at param of
     Just x  -> string' param x res
     Nothing -> Right res
 
-strings :: T.Text -> PuppetTypeValidate
+strings :: T.Text -> NativeTypeValidate
 strings param = runarray param string'
 
-string' :: T.Text -> PValue -> PuppetTypeValidate
+string' :: T.Text -> PValue -> NativeTypeValidate
 string' param rev res = case rev of
     PString _      -> Right res
     PBoolean True  -> Right (res & rattributes . at param ?~ PString "true")
@@ -125,7 +125,7 @@ string' param rev res = case rev of
 
 
 -- | Makes sure that the parameter, if defined, has a value among this list.
-values :: [T.Text] -> T.Text -> PuppetTypeValidate
+values :: [T.Text] -> T.Text -> NativeTypeValidate
 values valuelist param res = case res ^. rattributes . at param of
     Just (PString x) -> if x `elem` valuelist
         then Right res
@@ -134,29 +134,29 @@ values valuelist param res = case res ^. rattributes . at param of
     Nothing -> Right res
 
 -- | This fills the default values of unset parameters.
-defaultvalue :: T.Text -> T.Text -> PuppetTypeValidate
+defaultvalue :: T.Text -> T.Text -> NativeTypeValidate
 defaultvalue value param = Right . over (rattributes . at param) (Just . fromMaybe (PString value))
 
 -- | Checks that a given parameter, if set, is a 'ResolvedInt'. If it is a
 -- 'PString' it will attempt to parse it.
-integer :: T.Text -> PuppetTypeValidate
+integer :: T.Text -> NativeTypeValidate
 integer prm res = string prm res >>= integer' prm
     where
         integer' pr rs = case rs ^. rattributes . at pr of
             Just x  -> integer'' prm x res
             Nothing -> Right rs
 
-integers :: T.Text -> PuppetTypeValidate
+integers :: T.Text -> NativeTypeValidate
 integers param = runarray param integer''
 
-integer'' :: T.Text -> PValue -> PuppetTypeValidate
+integer'' :: T.Text -> PValue -> NativeTypeValidate
 integer'' param val res = case val ^? _Integer of
     Just v -> Right (res & rattributes . at param ?~ PNumber (fromIntegral v))
     _ -> perror $ "Parameter" <+> paramname param <+> "must be an integer"
 
 -- | Copies the "name" value into the parameter if this is not set. It implies
 -- the `string` validator.
-nameval :: T.Text -> PuppetTypeValidate
+nameval :: T.Text -> NativeTypeValidate
 nameval prm res = string prm res
                     >>= \r -> case r ^. rattributes . at prm of
                                   Just (PString al) -> Right (res & rid . iname .~ al)
@@ -164,7 +164,7 @@ nameval prm res = string prm res
                                   Nothing -> Right (r & rattributes . at prm ?~ PString (r ^. rid . iname))
 
 -- | Checks that a given parameter is set unless the resources "ensure" is set to absent
-mandatoryIfNotAbsent :: T.Text -> PuppetTypeValidate
+mandatoryIfNotAbsent :: T.Text -> NativeTypeValidate
 mandatoryIfNotAbsent param res = case res ^. rattributes . at param of
     Just _  -> Right res
     Nothing -> case res ^. rattributes . at "ensure" of
@@ -172,37 +172,37 @@ mandatoryIfNotAbsent param res = case res ^. rattributes . at param of
                    _ -> perror $ "Parameter" <+> paramname param <+> "should be set."
 
 -- | Checks that a given parameter is set.
-mandatory :: T.Text -> PuppetTypeValidate
+mandatory :: T.Text -> NativeTypeValidate
 mandatory param res = case res ^. rattributes . at param of
     Just _  -> Right res
     Nothing -> perror $ "Parameter" <+> paramname param <+> "should be set."
 
 -- | Helper that takes a list of stuff and will generate a validator.
-parameterFunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])] -> PuppetTypeValidate
+parameterFunctions :: [(T.Text, [T.Text -> NativeTypeValidate])] -> NativeTypeValidate
 parameterFunctions argrules rs = foldM parameterFunctions' rs argrules
     where
-    parameterFunctions' :: Resource -> (T.Text, [T.Text -> PuppetTypeValidate]) -> Either PrettyError Resource
+    parameterFunctions' :: Resource -> (T.Text, [T.Text -> NativeTypeValidate]) -> Either PrettyError Resource
     parameterFunctions' r (param, validationfunctions) = foldM (parameterFunctions'' param) r validationfunctions
-    parameterFunctions'' :: T.Text -> Resource -> (T.Text -> PuppetTypeValidate) -> Either PrettyError Resource
+    parameterFunctions'' :: T.Text -> Resource -> (T.Text -> NativeTypeValidate) -> Either PrettyError Resource
     parameterFunctions'' param r validationfunction = validationfunction param r
 
 -- checks that a parameter is fully qualified
-fullyQualified :: T.Text -> PuppetTypeValidate
+fullyQualified :: T.Text -> NativeTypeValidate
 fullyQualified param res = case res ^. rattributes . at param of
     Just path -> fullyQualified' param path res
     Nothing -> Right res
 
-noTrailingSlash :: T.Text -> PuppetTypeValidate
+noTrailingSlash :: T.Text -> NativeTypeValidate
 noTrailingSlash param res = case res ^. rattributes . at param of
      Just (PString x) -> if T.last x == '/'
                                     then perror ("Parameter" <+> paramname param <+> "should not have a trailing slash")
                                     else Right res
      _ -> Right res
 
-fullyQualifieds :: T.Text -> PuppetTypeValidate
+fullyQualifieds :: T.Text -> NativeTypeValidate
 fullyQualifieds param = runarray param fullyQualified'
 
-fullyQualified' :: T.Text -> PValue -> PuppetTypeValidate
+fullyQualified' :: T.Text -> PValue -> NativeTypeValidate
 fullyQualified' param path res = case path of
     PString ("")    -> perror $ "Empty path for parameter" <+> paramname param
     PString p -> if T.head p == '/'
@@ -210,13 +210,13 @@ fullyQualified' param path res = case path of
                             else perror $ "Path must be absolute, not" <+> ttext p <+> "for parameter" <+> paramname param
     x                -> perror $ "SHOULD NOT HAPPEN: path is not a resolved string, but" <+> pretty x <+> "for parameter" <+> paramname param
 
-rarray :: T.Text -> PuppetTypeValidate
+rarray :: T.Text -> NativeTypeValidate
 rarray param res = case res ^. rattributes . at param of
     Just (PArray _) -> Right res
     Just x          -> Right $ res & rattributes . at param ?~ PArray (V.singleton x)
     Nothing         -> Right res
 
-ipaddr :: T.Text -> PuppetTypeValidate
+ipaddr :: T.Text -> NativeTypeValidate
 ipaddr param res = case res ^. rattributes . at param of
     Nothing                  -> Right res
     Just (PString ip) ->
@@ -236,7 +236,7 @@ checkipv4 ip v =
         goodcur = not (T.null cur) && T.all isDigit cur && (let rcur = read (T.unpack cur) :: Int in (rcur >= 0) && (rcur <= 255))
     in goodcur && nextfunc
 
-inrange :: Integer -> Integer -> T.Text -> PuppetTypeValidate
+inrange :: Integer -> Integer -> T.Text -> NativeTypeValidate
 inrange mi ma param res =
     let va = res ^. rattributes . at param
         na = va ^? traverse . _Number
@@ -247,7 +247,7 @@ inrange mi ma param res =
                            else perror $ "Parameter" <+> paramname param P.<> "'s value should be between" <+> P.integer mi <+> "and" <+> P.integer ma
         (Just x,_)         -> perror $ "Parameter" <+> paramname param <+> "should be an integer, and not" <+> pretty x
 
-validateSourceOrContent :: PuppetTypeValidate
+validateSourceOrContent :: NativeTypeValidate
 validateSourceOrContent res = let
     parammap =  res ^. rattributes
     source    = HM.member "source"  parammap

--- a/Puppet/NativeTypes/Host.hs
+++ b/Puppet/NativeTypes/Host.hs
@@ -7,11 +7,11 @@ import qualified Data.Text as T
 import Control.Lens
 import qualified Data.Vector as V
 
-nativeHost :: (PuppetTypeName, PuppetTypeMethods)
+nativeHost :: (NativeTypeName, NativeTypeMethods)
 nativeHost = ("host", ptypemethods parameterfunctions return)
 
 -- Autorequires: If Puppet is managing the user or group that owns a file, the file resource will autorequire them. If Puppet is managing any parent directories of a file, the file resource will autorequire them.
-parameterfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+parameterfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 parameterfunctions =
     [("comment"      , [string, values ["true","false"]])
     ,("ensure"       , [defaultvalue "present", string, values ["present","absent"]])
@@ -22,7 +22,7 @@ parameterfunctions =
     ,("target"       , [string, fullyQualified])
     ]
 
-checkhostname :: T.Text -> PuppetTypeValidate
+checkhostname :: T.Text -> NativeTypeValidate
 checkhostname param res = case res ^. rattributes . at param of
     Nothing            -> Right res
     Just (PArray xs)   -> V.foldM (checkhostname' param) res xs

--- a/Puppet/NativeTypes/Mount.hs
+++ b/Puppet/NativeTypes/Mount.hs
@@ -4,10 +4,10 @@ import Puppet.NativeTypes.Helpers
 import Puppet.Interpreter.Types
 import qualified Data.Text as T
 
-nativeMount :: (PuppetTypeName, PuppetTypeMethods)
+nativeMount :: (NativeTypeName, NativeTypeMethods)
 nativeMount = ("mount", ptypemethods parameterfunctions return)
 
-parameterfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+parameterfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 parameterfunctions =
     [("atboot"      , [string, values ["true","false"]])
     ,("blockdevice" , [string])

--- a/Puppet/NativeTypes/Package.hs
+++ b/Puppet/NativeTypes/Package.hs
@@ -11,7 +11,7 @@ import Control.Lens
 import GHC.Generics
 import Data.Hashable
 
-nativePackage :: (PuppetTypeName, PuppetTypeMethods)
+nativePackage :: (NativeTypeName, NativeTypeMethods)
 nativePackage = ("package", ptypemethods parameterfunctions (getFeature >=> checkFeatures))
 
 data PackagingFeatures = Holdable | InstallOptions | Installable | Purgeable | UninstallOptions | Uninstallable | Upgradeable | Versionable deriving (Show, Eq, Generic)
@@ -55,7 +55,7 @@ isFeatureSupported = HM.fromList [ ("aix", HS.fromList [Installable, Uninstallab
                                   , ("zypper", HS.fromList [Installable, Uninstallable, Upgradeable, Versionable])
                                   ]
 
-parameterfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+parameterfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 parameterfunctions =
     [("adminfile"        , [string, fullyQualified])
     ,("allowcdrom"       , [string, values ["true","false"]])

--- a/Puppet/NativeTypes/SshSecure.hs
+++ b/Puppet/NativeTypes/SshSecure.hs
@@ -6,11 +6,11 @@ import Control.Monad.Error
 import qualified Data.Text as T
 import Control.Lens
 
-nativeSshSecure :: (PuppetTypeName, PuppetTypeMethods)
+nativeSshSecure :: (NativeTypeName, NativeTypeMethods)
 nativeSshSecure = ("ssh_authorized_key_secure", ptypemethods parameterfunctions (userOrTarget >=> keyIfPresent))
 
 -- Autorequires: If Puppet is managing the user or user that owns a file, the file resource will autorequire them. If Puppet is managing any parent directories of a file, the file resource will autorequire them.
-parameterfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+parameterfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 parameterfunctions =
     [("type"    , [string, defaultvalue "ssh-rsa", values ["rsa","dsa","ssh-rsa","ssh-dss"]])
     ,("key"     , [string])
@@ -20,13 +20,13 @@ parameterfunctions =
     ,("options" , [rarray, strings])
     ]
 
-userOrTarget :: PuppetTypeValidate
+userOrTarget :: NativeTypeValidate
 userOrTarget res = case (res ^. rattributes & has (ix "user"), res ^. rattributes & has (ix "target")) of
                        (False, False) -> Left "Parameters user or target are mandatory"
                        _              -> Right res
 
 
-keyIfPresent :: PuppetTypeValidate
+keyIfPresent :: NativeTypeValidate
 keyIfPresent res = case (res ^. rattributes . at "key", res ^. rattributes . at "ensure") of
                        (Just _, Just "present") -> Right res
                        (_, Just "absent")       -> Right res

--- a/Puppet/NativeTypes/User.hs
+++ b/Puppet/NativeTypes/User.hs
@@ -4,11 +4,11 @@ import Puppet.NativeTypes.Helpers
 import Puppet.Interpreter.Types
 import qualified Data.Text as T
 
-nativeUser :: (PuppetTypeName, PuppetTypeMethods)
+nativeUser :: (NativeTypeName, NativeTypeMethods)
 nativeUser = ("user", ptypemethods parameterfunctions return)
 
 -- Autorequires: If Puppet is managing the user or user that owns a file, the file resource will autorequire them. If Puppet is managing any parent directories of a file, the file resource will autorequire them.
-parameterfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+parameterfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 parameterfunctions =
     [("allowdupe"               , [string, defaultvalue "false", values ["true","false"]])
     ,("attribute_membership"    , [string, defaultvalue "minimum", values ["inclusive","minimum"]])

--- a/Puppet/NativeTypes/ZoneRecord.hs
+++ b/Puppet/NativeTypes/ZoneRecord.hs
@@ -6,11 +6,11 @@ import Control.Monad.Error
 import qualified Data.Text as T
 import Control.Lens
 
-nativeZoneRecord :: (PuppetTypeName, PuppetTypeMethods)
+nativeZoneRecord :: (NativeTypeName, NativeTypeMethods)
 nativeZoneRecord = ("zone_record", ptypemethods parameterfunctions validateMandatories)
 
 -- Autorequires: If Puppet is managing the user or group that owns a file, the file resource will autorequire them. If Puppet is managing any parent directories of a file, the file resource will autorequire them.
-parameterfunctions :: [(T.Text, [T.Text -> PuppetTypeValidate])]
+parameterfunctions :: [(T.Text, [T.Text -> NativeTypeValidate])]
 parameterfunctions =
     [("name"                , [nameval])
     ,("owner"               , [string])
@@ -29,7 +29,7 @@ parameterfunctions =
     ,("email"               , [string])
     ]
 
-validateMandatories :: PuppetTypeValidate
+validateMandatories :: NativeTypeValidate
 validateMandatories res = case res ^. rattributes . at "rtype" of
     Nothing              -> perror "The rtype parameter is mandatory."
     Just (PString "SOA") -> foldM (flip mandatory) res ["nsname", "email", "serial", "slave_refresh", "slave_retry", "slave_expiration", "min_ttl"]

--- a/Puppet/Preferences.hs
+++ b/Puppet/Preferences.hs
@@ -33,7 +33,7 @@ data Preferences m = Preferences
     , _modulesPath     :: FilePath -- ^ The path to the modules.
     , _templatesPath   :: FilePath -- ^ The path to the template.
     , _prefPDB         :: PuppetDBAPI m
-    , _natTypes        :: Container PuppetTypeMethods -- ^ The list of native types.
+    , _natTypes        :: Container NativeTypeMethods -- ^ The list of native types.
     , _prefExtFuncs    :: Container ( [PValue] -> InterpreterMonad PValue )
     , _hieraPath       :: Maybe FilePath
     , _ignoredmodules  :: HS.HashSet T.Text -- ^ The set of ignored modules


### PR DESCRIPTION
I was not sure if you'd prefer this to be a PR or not so in doubt I issue one.

"PuppetTypeMethods" was quite a confusing name for me. NativeTypeMethods seems better.
