### PR TITLE
Use ExceptT inplace of ErrorT.

### DIFF
--- a/Puppet/Interpreter/Types.hs
+++ b/Puppet/Interpreter/Types.hs
@@ -95,6 +95,7 @@ module Puppet.Interpreter.Types (
  , ifromListWith
  , ifromList
  , iunionWith
+ , showPos
  , fnull
  , rcurcontainer
  , logWriter
@@ -154,6 +155,10 @@ newtype PrettyError = PrettyError { getError :: Doc }
 
 instance Show PrettyError where
     show = show . getError
+
+instance Monoid PrettyError where
+    mempty = PrettyError mempty
+    mappend a b = PrettyError $ getError a <+> getError b
 
 instance IsString PrettyError where
     fromString = PrettyError . string

--- a/Puppet/OptionalTests.hs
+++ b/Puppet/OptionalTests.hs
@@ -1,11 +1,16 @@
 {-# LANGUAGE LambdaCase      #-}
-{-# LANGUAGE TemplateHaskell #-}
+-- | The module works in IO and exits on failure.
+-- It is meant to be use by a `Daemon`.
+-- PS: if more flexibility is needed, we can `throwM`
+-- on failure and let the caller choose what to do.
 module Puppet.OptionalTests (testCatalog) where
 
 import           Control.Applicative
 import           Control.Lens
-import           Control.Monad.Error
-import           Data.Foldable                    hiding (forM_, mapM_)
+import           Control.Monad                    (unless)
+import           Control.Monad.Trans              (liftIO)
+import           Control.Monad.Trans.Except
+import           Data.Foldable                    (msum, toList, elem)
 import           Data.Maybe                       (mapMaybe)
 import           Data.Monoid                      ((<>))
 import qualified Data.Text                        as T
@@ -13,6 +18,7 @@ import           Prelude                          hiding (all, elem)
 import           Puppet.Interpreter.PrettyPrinter ()
 import           Puppet.Interpreter.Types
 import           Puppet.PP                        hiding ((<$>))
+import           System.Exit                      (exitFailure)
 import           System.Posix.Files
 
 -- | Entry point for all optional tests
@@ -27,23 +33,37 @@ testFileSources basedir c = do
                         && (r ^. rattributes . at "ensure") `elem` [Nothing, Just "present"]
                         && r ^. rattributes . at "source" /= Just PUndef
         getSource = mapMaybe (\r -> (,) <$> pure r <*> r ^. rattributes . at "source")
-    let files = (getSource . getFiles) c
-    forM_ files $ \(_, filesource) -> do
-        rs <- runErrorT (checkFile basedir filesource)
-        case rs of
-             Right () -> return ()
-             Left err -> fail (show err)
+    checkAllSources basedir $ (getSource . getFiles) c
 
-testFile :: FilePath -> ErrorT PrettyError IO ()
-testFile fp = liftIO (fileExist fp) >>= (`unless` (throwError $ PrettyError $ "Searched in" <+> string fp))
+-- | Check source for all file resources and append failures along.
+checkAllSources :: FilePath -> [(Resource, PValue)] -> IO ()
+checkAllSources fp fs = go fs []
+  where
+    go ((res, filesource):xs) es =
+      runExceptT (checkFile fp filesource) >>= \case
+        Right () -> go xs es
+        Left err -> go xs ((PrettyError $ "Could not find " <+> pretty filesource <> semi
+                           <+> align (vsep [getError err, showPos (res^.rpos^._1)])):es)
+    go [] [] = return ()
+    go [] es = do
+      mapM_(\e -> putDoc $ getError e <> line) es
+      exitFailure
 
-checkFile :: FilePath -> PValue -> ErrorT PrettyError IO ()
-checkFile basedir (PString f) = case (T.stripPrefix "puppet:///" f, T.stripPrefix "file:///" f) of
-    (Just stringdir, _) -> case T.splitOn "/" stringdir of
+testFile :: FilePath -> ExceptT PrettyError IO ()
+testFile fp = do
+    p <-  liftIO (fileExist fp)
+    unless p (throwE $ PrettyError $ "searched in" <+> squotes (string fp))
+
+-- | Only test the `puppet:///` protocol (files managed by the puppet server)
+--   we don't test absolute path (puppet client files)
+checkFile :: FilePath -> PValue -> ExceptT PrettyError IO ()
+checkFile basedir (PString f) = case T.stripPrefix "puppet:///" f of
+    Just stringdir -> case T.splitOn "/" stringdir of
         ("modules":modname:rest) -> testFile (basedir <> "/modules/" <> T.unpack modname <> "/files/" <> T.unpack (T.intercalate "/" rest))
         ("files":rest)           -> testFile (basedir <> "/files/" <> T.unpack (T.intercalate "/" rest))
         ("private":_)            -> return ()
-        _                        -> throwError (PrettyError $ "Invalid file source:" <+> ttext f)
-    (Nothing, _)        -> return ()
-checkFile basedir pv@(PArray xs) = asum [checkFile basedir x | x <- toList xs] <|> throwError (PrettyError $ "Could not find the file in" <+> pretty pv)
-checkFile _ x = throwError (PrettyError $ "Source was not a string, but" <+> pretty x)
+        _                        -> throwE (PrettyError $ "Invalid file source:" <+> ttext f)
+    Nothing        -> return ()
+-- source is always an array of possible paths. We only fails if none of them check.
+checkFile basedir (PArray xs) = msum [checkFile basedir x | x <- toList xs]
+checkFile _ x = throwE (PrettyError $ "Source was not a string, but" <+> pretty x)

--- a/Puppet/Plugins.hs
+++ b/Puppet/Plugins.hs
@@ -37,7 +37,6 @@ import System.IO
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Vector as V
-import Control.Monad.IO.Class
 import Control.Concurrent
 import Control.Monad.Error
 import Control.Monad.Operational (singleton)

--- a/language-puppet.cabal
+++ b/language-puppet.cabal
@@ -109,7 +109,7 @@ library
                         , strict-base-types    >= 0.2.2
                         , text                 >= 0.11
                         , time                 == 1.4.*
-                        , transformers         == 0.3.*
+                        , transformers-compat  == 0.4.*
                         , unix                 >= 2.6     && < 2.8
                         , unordered-containers == 0.2.*
                         , vector               == 0.10.*


### PR DESCRIPTION
* Don't check `file:///` protocol in optional tests
* Check all sources instead of stopping at the first failure
* Display failure position

Thanks for reviewing these changes.

I think it is alright. I had to add the `Monoid` instance because with ExceptT that's the new constraint (instead of Error).

There might be a way to abstract `checkAllSources` with a generic function but I found it more flexible to handle it explicitly.

The reason for the PR is the dependency changes (from `transformer-3.x` to `transformers-compat`).