### PR TITLE
Use Either instead of strict Either for puppetDB

### DIFF
--- a/Puppet/Preferences.hs
+++ b/Puppet/Preferences.hs
@@ -66,6 +66,7 @@ data Defaults = Defaults
     , _dfExtratests      :: Maybe Bool
     , _dfExternalmodules :: Maybe [Text]
     , _dfPuppetSettings  :: Maybe (Container Text)
+    , _dfFactsDefault    :: Maybe (Container PValue)
     , _dfFactsOverride   :: Maybe (Container PValue)
     } deriving Show
 
@@ -81,6 +82,7 @@ instance FromJSON Defaults where
                            <*> v .:? "extratests"
                            <*> v .:? "externalmodules"
                            <*> v .:? "settings"
+                           <*> v .:? "factsdefault"
                            <*> v .:? "factsoverride"
     parseJSON _ = mzero
 
@@ -107,7 +109,7 @@ dfPreferences basedir = do
                          (getKnowngroups defaults)
                          (getExternalmodules defaults)
                          (getPuppetSettings dirpaths defaults)
-                         (getFactsOverride defaults)
+                         (getFactsOverride defaults `HM.union` getFactsDefault defaults)
 
 loadDefaults :: FilePath -> IO (Maybe Defaults)
 loadDefaults fp = do
@@ -145,3 +147,6 @@ getPuppetSettings dirpaths = fromMaybe df . (>>= _dfPuppetSettings)
 
 getFactsOverride :: Maybe Defaults -> Container PValue
 getFactsOverride = fromMaybe mempty . (>>= _dfFactsOverride)
+
+getFactsDefault :: Maybe Defaults -> Container PValue
+getFactsDefault = fromMaybe mempty . (>>= _dfFactsDefault)

--- a/Puppet/Preferences.hs
+++ b/Puppet/Preferences.hs
@@ -55,6 +55,7 @@ data Preferences m = Preferences
     , _knowngroups     :: [Text]
     , _externalmodules :: HS.HashSet Text
     , _puppetSettings  :: Container Text
+    , _factsOverride   :: Container PValue
     }
 
 data Defaults = Defaults
@@ -65,6 +66,7 @@ data Defaults = Defaults
     , _dfExtratests      :: Maybe Bool
     , _dfExternalmodules :: Maybe [Text]
     , _dfPuppetSettings  :: Maybe (Container Text)
+    , _dfFactsOverride   :: Maybe (Container PValue)
     } deriving Show
 
 
@@ -79,6 +81,7 @@ instance FromJSON Defaults where
                            <*> v .:? "extratests"
                            <*> v .:? "externalmodules"
                            <*> v .:? "settings"
+                           <*> v .:? "factsoverride"
     parseJSON _ = mzero
 
 -- | generate default preferences
@@ -104,6 +107,7 @@ dfPreferences basedir = do
                          (getKnowngroups defaults)
                          (getExternalmodules defaults)
                          (getPuppetSettings dirpaths defaults)
+                         (getFactsOverride defaults)
 
 loadDefaults :: FilePath -> IO (Maybe Defaults)
 loadDefaults fp = do
@@ -138,3 +142,6 @@ getPuppetSettings dirpaths = fromMaybe df . (>>= _dfPuppetSettings)
       df :: Container Text
       df = HM.fromList [ ("confdir", T.pack $ dirpaths^.baseDir)
                        ]
+
+getFactsOverride :: Maybe Defaults -> Container PValue
+getFactsOverride = fromMaybe mempty . (>>= _dfFactsOverride)

--- a/PuppetDB/Common.hs
+++ b/PuppetDB/Common.hs
@@ -11,7 +11,6 @@ import Data.Maybe
 import Data.List (stripPrefix)
 import Control.Lens
 import System.Environment
-import qualified Data.Either.Strict as S
 import Data.Vector.Lens
 import Servant.Common.BaseUrl
 
@@ -38,13 +37,13 @@ instance Read PDBType where
             tsts = stripPrefix "test"      r
 
 -- | Given a 'PDBType', will try return a sane default implementation.
-getDefaultDB :: PDBType -> IO (S.Either PrettyError (PuppetDBAPI IO))
-getDefaultDB PDBDummy  = return (S.Right dummyPuppetDB)
+getDefaultDB :: PDBType -> IO (Either PrettyError (PuppetDBAPI IO))
+getDefaultDB PDBDummy  = return (Right dummyPuppetDB)
 getDefaultDB PDBRemote = let Right url = parseBaseUrl "http://localhost:8080"
                          in  pdbConnect url
 getDefaultDB PDBTest   = lookupEnv "HOME" >>= \case
                                 Just h -> loadTestDB (h ++ "/.testdb")
-                                Nothing -> fmap S.Right initTestDB
+                                Nothing -> fmap Right initTestDB
 
 -- | Turns a 'FinalCatalog' and 'EdgeMap' into a document that can be
 -- serialized and fed to @puppet apply@.

--- a/PuppetDB/Remote.hs
+++ b/PuppetDB/Remote.hs
@@ -10,7 +10,6 @@ import Puppet.PP
 import Puppet.Interpreter.Types
 import Data.Text (Text)
 import Control.Monad.Trans.Either
-import qualified Data.Either.Strict as S
 import Servant.API
 import Servant.Client
 import Data.Aeson
@@ -27,9 +26,9 @@ api :: Proxy PDBAPI
 api = Proxy
 
 -- | Given an URL (ie. @http://localhost:8080@), will return an incomplete 'PuppetDBAPI'.
-pdbConnect :: BaseUrl -> IO (S.Either PrettyError (PuppetDBAPI IO))
+pdbConnect :: BaseUrl -> IO (Either PrettyError (PuppetDBAPI IO))
 pdbConnect url =
-    return $ S.Right $ PuppetDBAPI
+    return $ Right $ PuppetDBAPI
         (return (string $ show url))
         (const (left "operation not supported"))
         (const (left "operation not supported"))

--- a/README.adoc
+++ b/README.adoc
@@ -95,11 +95,6 @@ When this flag is set, exported resources are saved in the PuppetDB. This is use
 
 Displays the catalog as a Puppet-compatible JSON file, that can then be used with `puppet apply`.
 
-`--facts-override` and `--facts-defaults`::
-
-Both options expect a path to a YAML file defining facts. The first option will override the facts that are collected locally, while the second will merely provide default values
-for them.
-
 `--strict`::
 
 Enable strict check.

--- a/language-puppet.cabal
+++ b/language-puppet.cabal
@@ -78,9 +78,9 @@ library
   ghc-options:         -Wall -funbox-strict-fields
   ghc-prof-options:    -auto-all -caf-all
   build-depends:       base >=4.6 && < 4.9
-                        , aeson                >= 0.7     && < 0.9
+                        , aeson                >= 0.8     && < 0.9
                         , ansi-wl-pprint       == 0.6.*
-                        , attoparsec           >= 0.12    && < 0.14
+                        , attoparsec           >= 0.13    && < 0.14
                         , base16-bytestring    == 0.1.*
                         , bytestring
                         , case-insensitive     == 1.2.*
@@ -91,7 +91,7 @@ library
                         , exceptions           >= 0.8     && < 0.9
                         , filecache            >= 0.2.8   && < 0.3
                         , hashable             == 1.2.*
-                        , hruby                >= 0.3.1.3 && <0.4
+                        , hruby                >= 0.3.1.4 && <0.4
                         , hslogger             == 1.2.*
                         , hslua                >= 0.3.10  && < 0.4
                         , lens                 >= 4.9     && < 5

--- a/progs/PuppetResources.hs
+++ b/progs/PuppetResources.hs
@@ -72,8 +72,6 @@ data Options = Options
     , _optPdbfile      :: Maybe FilePath
     , _optLoglevel     :: LOG.Priority
     , _optHieraFile    :: Maybe FilePath
-    , _optFactsOverr   :: Maybe FilePath
-    , _optFactsDefault :: Maybe FilePath
     , _optCommitDB     :: Bool
     , _optCheckExport  :: Bool
     , _optIgnoredMods  :: Maybe (HS.HashSet T.Text)
@@ -130,12 +128,6 @@ options = Options
        (  long "hiera"
        <> help "Path to the Hiera configuration file (default hiera.yaml)"
        <> value "hiera.yaml"))
-   <*> optional (strOption
-       (  long "facts-override"
-       <> help "Path to a Yaml file containing a list of 'facts' that will override locally resolved facts"))
-   <*> optional (strOption
-       (  long "facts-defaults"
-       <> help "Path to a Yaml file containing a list of 'facts' that will be used as defaults"))
    <*> switch
        (  long "commitdb"
        <> help "Commit the computed catalogs in the puppetDB")

--- a/progs/PuppetResources.hs
+++ b/progs/PuppetResources.hs
@@ -157,9 +157,9 @@ options = Options
        (  long "noextratests"
        <> help "Disable extra tests (eg.: check that files exist on local disk")
 
-checkError :: Doc -> S.Either PrettyError a -> IO a
-checkError r (S.Left rr) = error (show (red r <> ": " <+> getError rr))
-checkError _ (S.Right x) = return x
+checkError :: Doc -> Either PrettyError a -> IO a
+checkError r (Left rr) = error (show (red r <> ": " <+> getError rr))
+checkError _ (Right x) = return x
 
 -- | Like catMaybes, but it counts the Nothing values
 catMaybesCount :: [Maybe a] -> ([a], Sum Int)
@@ -181,7 +181,7 @@ initializedaemonWithPuppet workingdir (Options {..}) = do
     pdbapi <- case (_optPdburl, _optPdbfile) of
                   (Nothing, Nothing) -> return dummyPuppetDB
                   (Just _, Just _)   -> error "You must choose between a testing PuppetDB and a remote one"
-                  (Just url, _)      -> checkError "Error when parsing url" (parseBaseUrl url & either (S.Left . fromString) S.Right)
+                  (Just url, _)      -> checkError "Error when parsing url" (parseBaseUrl url & either (Left . fromString) Right)
                                             >>= pdbConnect
                                             >>= checkError "Error when connecting to the remote PuppetDB"
                   (_, Just file)     -> loadTestDB file >>= checkError "Error when initializing the PuppetDB API"

--- a/progs/PuppetResources.hs
+++ b/progs/PuppetResources.hs
@@ -190,7 +190,7 @@ initializedaemonWithPuppet workingdir (Options {..}) = do
                                     <&> (if _optStrictMode then strictness .~ Strict else id)
                                     <&> (if _optNoExtraTests then extraTests .~ False else id)
     q <- initDaemon prf
-    let queryfunc = \node -> fmap (HM.union (prf^.factsOverride)) (puppetDBFacts node pdbapi) >>= _dGetCatalog q node
+    let queryfunc = \node -> fmap (`HM.union` (prf^.factsOverride)) (puppetDBFacts node pdbapi) >>= _dGetCatalog q node
     return (queryfunc, pdbapi, _dParserStats q, _dCatalogStats q, _dTemplateStats q)
 
 

--- a/progs/pdbQuery.hs
+++ b/progs/pdbQuery.hs
@@ -96,14 +96,14 @@ run cmdl = do
                    (Just l, PDBTest)   -> loadTestDB l
                    (_, x)              -> getDefaultDB x
     pdbapi <- case epdbapi of
-                  S.Left r -> error (show r)
-                  S.Right x -> return x
+                  Left r -> error (show r)
+                  Right x -> return x
     case _pdbcmd cmdl of
         DumpFacts -> if _pdbtype cmdl == PDBDummy
                          then puppetDBFacts "dummy"  pdbapi >>= mapM_ print . HM.toList
                          else do
                              allfacts <- runCheck "get facts" (getFacts pdbapi QEmpty)
-                             tmpdb <- loadTestDB "/tmp/allfacts.yaml" >>= checkErrorS "load test db"
+                             tmpdb <- loadTestDB "/tmp/allfacts.yaml" >>= checkError "load test db"
                              let groupfacts = foldl' groupfact HM.empty allfacts
                                  groupfact curmap (PFactInfo ndname fctname fctval) =
                                      curmap & at ndname . non HM.empty %~ (at fctname ?~ fctval)
@@ -116,7 +116,7 @@ run cmdl = do
             runCheck "replace facts" (replaceFacts pdbapi [(n, fcts)])
             runCheck "commit db" (commitDB pdbapi)
         CreateTestDB destfile -> do
-            ndb <- loadTestDB destfile >>= checkErrorS "puppetdb load"
+            ndb <- loadTestDB destfile >>= checkError "puppetdb load"
             allnodes <- runCheck "get nodes" (getNodes pdbapi QEmpty)
             allfacts <- runCheck "get facts" (getFacts pdbapi QEmpty)
             let factsGrouped = HM.toList $ HM.fromListWith (<>) $ map (\x -> (x ^. nodename, HM.singleton (x ^. factname) (x ^. factval))) allfacts

--- a/tests/defaults.yaml
+++ b/tests/defaults.yaml
@@ -1,33 +1,47 @@
 knownusers:
-  - mysql
-  - nagios
   - nginx
   - postgres
   - puppet
   - root
-  - stash
   - syslog
-  - vagrant
-  - www-data
 
 knowngroups:
   - adm
-  - mysql
-  - nagios
   - postgres
   - puppet
   - root
-  - stash
   - syslog
-  - vagrant
   - www-data
 
+factsdefault:
+  subgroup:
+
+factsoverride:
+  puppetversion: 3.7.5
+  id: unitesting
+  fqdn: utesting
+  architecture: x86_64
+  osfamily: RedHat
+  operatingsystem: CentOS
+  operatingsystemmajrelease: '6'
+  lsbmajdistrelease: 6
+  lsbdistid: RH
+  operatingsystemrelease: '6.6'
+  kernel: linux
+  kernelrelease: 3.10.42-1-lts
+  kernelversion: 2.6.32
+  kernelmajversion: '2.6.5'
+  ipaddress: 127.0.0.1
+  concat_basedir: /tmp
+  path: /usr/local/sbin:/usr/local/bin:/usr/bin
+
 ignoredmodules:
-  - java
+  - maven
 
 externalmodules:
   - nginx
-  - jenkins
+  - postgresql
+  - docker
 
 strict: true
 


### PR DESCRIPTION
I don't believe the strict version add anything while dealing with the PuppetDBAPI so this might be a first step in trying to simplify the error handling bits.

What do you think ?