### PR TITLE
Migrate from cryptohash to cryptonite

### DIFF
--- a/Puppet/Puppetlabs.hs
+++ b/Puppet/Puppetlabs.hs
@@ -3,6 +3,7 @@ module Puppet.Puppetlabs (extFunctions) where
 
 import           Control.Lens
 import           Crypto.Hash                      as Crypto
+import           Data.ByteArray (convert)
 import           Data.ByteString                  (ByteString)
 import           Data.Foldable                    (foldlM)
 import qualified Data.HashMap.Strict              as HM
@@ -22,7 +23,7 @@ import           Puppet.Interpreter.Types
 import           Puppet.PP
 
 md5 :: Text -> Text
-md5 = Text.decodeUtf8 . digestToHexByteString . (Crypto.hash :: ByteString -> Digest MD5) . Text.encodeUtf8
+md5 = Text.pack . show . (Crypto.hash :: ByteString -> Digest MD5) . Text.encodeUtf8
 
 extFun :: [(FilePath, Text, [PValue] -> InterpreterMonad PValue)]
 extFun =  [ ("/postgresql", "postgresql_acls_to_resources_hash", pgAclsToHash)

--- a/language-puppet.cabal
+++ b/language-puppet.cabal
@@ -86,7 +86,7 @@ library
                         , bytestring
                         , case-insensitive     == 1.2.*
                         , containers           == 0.5.*
-                        , cryptohash           >= 0.10    && < 0.12
+                        , cryptonite           >= 0.6
                         , directory            == 1.2.*
                         , either               >= 4.3     && < 4.5
                         , exceptions           >= 0.8     && < 0.9
@@ -98,6 +98,7 @@ library
                         , hslua                >= 0.4     && < 0.5
                         , lens                 >= 4.9     && < 5
                         , lens-aeson           >= 1.0
+                        , memory               >= 0.7
                         , mtl                  >= 2.2     && < 2.3
                         , operational          >= 0.2.3   && < 0.3
                         , parsec               == 3.1.*


### PR DESCRIPTION
Are you Ok with the following change ?

Then a question. What's the best way to replace 
```
md5 :: Text -> Text
md5 = Text.decodeUtf8 . digestToHexByteString . (Crypto.hash :: ByteString -> Digest MD5) . Text.encodeUtf8
```

`toHex` or `B.convertToBase B.Base16 bs :: Bytes` does not seem to be exposed by `cryptonite` ... Should we use [base16-bytestring-0.1.1.6](https://hackage.haskell.org/package/base16-bytestring-0.1.1.6/docs/Data-ByteString-Base16.html) ?

Of course the `pack.show` trick is OK for my situation. I am just wondering about best practices.
