### PR TITLE
Relax lower bound

### DIFF
--- a/language-puppet.cabal
+++ b/language-puppet.cabal
@@ -98,7 +98,7 @@ library
                      , formatting
                      , hashable             == 1.2.*
                      , http-api-data        >= 0.2   && < 0.4
-                     , http-client          >= 0.5   && < 0.6
+                     , http-client          >= 0.4.30 && < 0.6
                      , hruby                >= 0.3.2 && < 0.4
                      , hslogger             == 1.2.*
                      , hspec

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,8 +2,6 @@ flags: {}
 packages:
 - '.'
 extra-deps:
-  - http-client-0.5.2
-  - http-client-tls-0.3.0
   - servant-0.8
   - servant-client-0.8
   - http-api-date-0.3


### PR DESCRIPTION
Tried locally, compiles.

Would let newest `language-puppet` to get into nightlies (as it wouldn't be blocked by http-client-0.5 not yet there).

Related to https://github.com/fpco/stackage/pull/1864

*EDIT* a new revsion edit on the Hackage would be enough for this