### PR TITLE
Add 'pdbquery facts' subcommand

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,9 @@
 # v1.3.3 (2016/10/16)
 
-* Fix `pdbquery dumpres NODENAME`
+* Rename some pdbquery subcommands
+* Output pdbquery in `json` instead of `yaml`
+* Fix `pdbquery resources NODENAME`
+* Add `pdbquery fact NODENAME`
 
 # v1.3.2.1 (2016/10/04)
 

--- a/README.adoc
+++ b/README.adoc
@@ -129,8 +129,12 @@ Please look at https://github.com/bartavelle/language-puppet/blob/master/tests/d
 
 == pdbQuery
 
-The `pdbQuery` command is used to work with different implementations of PuppetDB (the official one with its HTTP API, the file-based backend and dummy ones). Its main use is to
-export data from production PuppetDB to a file in order to debug some issue with `puppetresources`. Here is a list of command line arguments :
+The `pdbquery` command will work with different implementations of PuppetDB (the official one with its HTTP API, the file-based backend and dummy ones). It can be used to:
+
+* export data from production PuppetDB to a file (in order to debug some issue with `puppetresources`).
+* query a Puppetdb
+
+Here is a list of command line arguments :
 
 `-l` or `--location`::
 
@@ -145,28 +149,26 @@ The type of PuppetDB to work with:
 * test: a file-based backend emulating a PuppetDB.
 
 .Commands
-`dumpfacts`::
 
-Dump all facts, and store them in `/tmp/allfacts.yaml`.
+`facts`::
+Output facts for a specific node (json)
 
 `nodes`::
+Output all nodes (json)
 
-Dump all nodes
+`resources`::
+Output all resources for a specific node (json)
 
-`dumpres`::
-
-Dump all resources for a specific node
+`dumpfacts`::
+Dump all facts to `/tmp/allfacts.yaml`.
 
 `snapshot`::
-
 Create a test DB from the current DB
 
 `addfacts`::
-
 Adds facts to the test DB for the given node name, if they are not already defined.
 
 `--version`::
-
 Output version information and exit.
 
 == Unsupported Puppet idioms or features

--- a/default.nix
+++ b/default.nix
@@ -1,30 +1,28 @@
-{ mkDerivation, aeson, ansi-wl-pprint, attoparsec, base
-, base16-bytestring, bytestring, case-insensitive, containers
+{ mkDerivation, fetchFromGitHub, aeson, ansi-wl-pprint, attoparsec
+, base, base16-bytestring, bytestring, case-insensitive, containers
 , cryptonite, directory, either, exceptions, filecache, formatting
-, Glob, hashable, hruby, hslogger, hslua, hspec, hspec-megaparsec
+, Glob, hashable, hruby, hslogger, hspec, hspec-megaparsec
 , http-api-data, http-client, HUnit, lens, lens-aeson, megaparsec
 , memory, mtl, operational, optparse-applicative, parallel-io
 , parsec, pcre-utils, process, random, regex-pcre-builtin
 , scientific, semigroups, servant, servant-client, split, stdenv
 , stm, strict-base-types, temporary, text, time, transformers, unix
-, unordered-containers, vector, yaml
-, ruby, glpk, pcre, zlib
+, unordered-containers, vector, yaml, ruby, pcre, zlib
 }:
 mkDerivation {
   pname = "language-puppet";
-  version = "1.1.5.1";
+  version = "1.3.3";
   src = ./.;
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
     aeson ansi-wl-pprint attoparsec base base16-bytestring bytestring
     case-insensitive containers cryptonite directory either exceptions
-    filecache formatting hashable hruby hslogger hslua hspec
-    http-api-data http-client lens lens-aeson megaparsec memory mtl
-    operational parsec pcre-utils process random regex-pcre-builtin
-    scientific semigroups servant servant-client split stm
-    strict-base-types text time transformers unix unordered-containers
-    vector yaml
+    filecache formatting hashable hruby hslogger hspec http-api-data
+    http-client lens lens-aeson megaparsec memory mtl operational
+    parsec pcre-utils process random regex-pcre-builtin scientific
+    semigroups servant servant-client split stm strict-base-types text
+    time transformers unix unordered-containers vector yaml
   ];
   executableHaskellDepends = [
     aeson base bytestring containers Glob hslogger http-client lens
@@ -37,7 +35,7 @@ mkDerivation {
     megaparsec mtl scientific strict-base-types temporary text
     transformers unix unordered-containers vector
   ];
-  libraryPkgconfigDepends = [ ruby glpk pcre zlib ];
+  libraryPkgconfigDepends = [ ruby pcre zlib ];
   homepage = "http://lpuppet.banquise.net/";
   description = "Tools to parse and evaluate the Puppet DSL";
   license = stdenv.lib.licenses.bsd3;

--- a/language-puppet.cabal
+++ b/language-puppet.cabal
@@ -219,6 +219,7 @@ executable pdbquery
   ghc-options:         -Wall -rtsopts -threaded
   -- ghc-prof-options:    -auto-all -caf-all -fprof-auto
   build-depends:       base
+                     , aeson
                      , bytestring
                      , http-client
                      , language-puppet


### PR DESCRIPTION
I have changed the output (not dump) format of the pdbquery command.

It is much more handy on my side (as I can use `jq` to get a nice display).

Are you ok with that ?