### PR TITLE
Use normal Either type instead of the strict variant in the Daemon API

### DIFF
--- a/Puppet/Daemon.hs
+++ b/Puppet/Daemon.hs
@@ -58,7 +58,7 @@ Notes :
 * It might be buggy when top level statements that are not class\/define\/nodes are altered.
 -}
 data Daemon = Daemon
-    { getCatalog    :: NodeName -> Facts -> IO (S.Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))
+    { getCatalog    :: NodeName -> Facts -> IO (Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))
     , parserStats   :: MStats
     , catalogStats  :: MStats
     , templateStats :: MStats
@@ -117,7 +117,7 @@ getCatalog' :: Preferences IO
          -> HieraQueryFunc IO
          -> NodeName
          -> Facts
-         -> IO (S.Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))
+         -> IO (Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))
 getCatalog' pref parsingfunc getTemplate stats hquery node facts = do
     logDebug ("Received query for node " <> node)
     traceEventIO ("START getCatalog' " <> T.unpack node)
@@ -144,13 +144,13 @@ getCatalog' pref parsingfunc getTemplate stats hquery node facts = do
     traceEventIO ("STOP getCatalog' " <> T.unpack node)
     if pref ^. prefExtraTests
        then runOptionalTests stmts
-       else return stmts
+       else pure stmts
     where
-      runOptionalTests stm = case stm ^? S._Right._1 of
-          Nothing  -> return stm
+      runOptionalTests stm = case stm ^? _Right._1 of
+          Nothing  -> pure stm
           (Just c) -> catching _PrettyError
-                              (do {testCatalog pref c; return stm})
-                              (return . S.Left)
+                              (do {testCatalog pref c; pure stm})
+                              (pure . Left)
 
 -- | Return an HOF that would parse the file associated with a toplevel.
 -- The toplevel is defined by the tuple (type, name)

--- a/Puppet/Interpreter.hs
+++ b/Puppet/Interpreter.hs
@@ -13,7 +13,6 @@ import           Control.Monad.Except
 import           Control.Monad.Operational        hiding (view)
 import           Control.Monad.Trans.Except
 import           Data.Char                        (isDigit)
-import qualified Data.Either.Strict               as S
 import           Data.Foldable                    (foldl', foldlM, toList)
 import qualified Data.Graph                       as G
 import qualified Data.HashMap.Strict              as HM
@@ -58,10 +57,10 @@ interpretCatalog :: Monad m
                  -> NodeName
                  -> Facts
                  -> Container Text -- ^ Server settings
-                 -> m (Pair (S.Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))  [Pair Priority Doc])
+                 -> m (Pair (Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))  [Pair Priority Doc])
 interpretCatalog interpretReader node facts settings = do
     (output, _, warnings) <- interpretMonad interpretReader (initialState facts settings) (computeCatalog node)
-    return (strictifyEither output :!: warnings)
+    pure (output :!: warnings)
 
 isParent :: Text -> CurContainerDesc -> InterpreterMonad Bool
 isParent cur (ContClass possibleparent) = preuse (scopes . ix cur . scopeParent) >>= \case

--- a/progs/yera.hs
+++ b/progs/yera.hs
@@ -1,11 +1,13 @@
+{-# LANGUAGE LambdaCase #-}
 module Main (main) where
-  
+
 import           Options.Applicative
 import           Data.Monoid
 import qualified Data.Text as T
 import qualified Data.Either.Strict as S
 import qualified Data.HashMap.Strict as HM
 import           Text.PrettyPrint.ANSI.Leijen (pretty)
+import System.Exit
 
 import Puppet.Interpreter.Types
 import Puppet.Interpreter.PrettyPrinter()
@@ -48,12 +50,8 @@ configInfo = info (configParser <**> helper) mempty
 main :: IO ()
 main = do
   Config fp query qtype vars <- execParser configInfo
-  ehiera <- startHiera fp
-  case ehiera of
-    Left rr -> error rr
-    Right hiera -> do
-      r <- hiera (HM.fromList vars) (T.pack query) qtype
-      case r of
-        S.Left rr -> error (show rr)
-        S.Right Nothing -> putStrLn "no match"
-        S.Right (Just res) -> print (pretty res)
+  hiera <- startHiera' fp
+  hiera (HM.fromList vars) (T.pack query) qtype >>= \case
+    S.Left rr -> error (show rr)
+    S.Right Nothing -> putStrLn "no match" >> exitFailure
+    S.Right (Just res) -> print (pretty res)


### PR DESCRIPTION
I would like to propose the use of the normal `Either` type in the interface of `Daemon`.

In my own code I actually do something like this:

```
    r <- liftIO $ getCatalog (puppet ^.daemon) (Text.pack node) facts
    case r of
      Right _ ->
        liftIO $ withFile out WriteMode (\h -> hPutDoc h ( dullgreen "✓" <+> text node))
      Left msg ->
        liftIO $ withFile out WriteMode (\h -> hPutDoc h ( char 'x' <> space <> dullred (text node) <> colon <+> getError msg ))

```

Maybe there is an hidden reason for using the strict type that I don't understand. Asking a bit around it seems that the need for a strict variant should be quite uncommon:

https://www.reddit.com/r/haskell/comments/74rvnx/weekly_beginner_saturday_hask_anything_7/do1m70m/

My understanding is that the lazy common variant is more general and thus more suited to an api such as found in Daemon.hs