### PR TITLE
Remove startHiera to use startHiera' exclusively

### DIFF
--- a/Puppet/Daemon.hs
+++ b/Puppet/Daemon.hs
@@ -84,8 +84,8 @@ initDaemon pref = do
     logDebug "initDaemon"
     traceEventIO "initDaemon"
     hquery <- case pref ^. prefHieraPath of
-                  Just p  -> either error id <$> startHiera p
-                  Nothing -> return dummyHiera
+                  Just p  -> startHiera p
+                  Nothing -> pure dummyHiera
     fcache      <- newFileCache
     intr        <- startRubyInterpreter
     templStats  <- newStats

--- a/Puppet/Daemon.hs
+++ b/Puppet/Daemon.hs
@@ -58,7 +58,7 @@ Notes :
 * It might be buggy when top level statements that are not class\/define\/nodes are altered.
 -}
 data Daemon = Daemon
-    { getCatalog    :: NodeName -> Facts -> IO (S.Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))
+    { getCatalog    :: NodeName -> Facts -> IO (Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))
     , parserStats   :: MStats
     , catalogStats  :: MStats
     , templateStats :: MStats
@@ -117,7 +117,7 @@ getCatalog' :: Preferences IO
          -> HieraQueryFunc IO
          -> NodeName
          -> Facts
-         -> IO (S.Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))
+         -> IO (Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))
 getCatalog' pref parsingfunc getTemplate stats hquery node facts = do
     logDebug ("Received query for node " <> node)
     traceEventIO ("START getCatalog' " <> T.unpack node)
@@ -144,13 +144,13 @@ getCatalog' pref parsingfunc getTemplate stats hquery node facts = do
     traceEventIO ("STOP getCatalog' " <> T.unpack node)
     if pref ^. prefExtraTests
        then runOptionalTests stmts
-       else return stmts
+       else pure stmts
     where
-      runOptionalTests stm = case stm ^? S._Right._1 of
-          Nothing  -> return stm
+      runOptionalTests stm = case stm ^? _Right._1 of
+          Nothing  -> pure stm
           (Just c) -> catching _PrettyError
-                              (do {testCatalog pref c; return stm})
-                              (return . S.Left)
+                              (do {testCatalog pref c; pure stm})
+                              (pure . Left)
 
 -- | Return an HOF that would parse the file associated with a toplevel.
 -- The toplevel is defined by the tuple (type, name)

--- a/Puppet/Interpreter.hs
+++ b/Puppet/Interpreter.hs
@@ -13,7 +13,6 @@ import           Control.Monad.Except
 import           Control.Monad.Operational        hiding (view)
 import           Control.Monad.Trans.Except
 import           Data.Char                        (isDigit)
-import qualified Data.Either.Strict               as S
 import           Data.Foldable                    (foldl', foldlM, toList)
 import qualified Data.Graph                       as G
 import qualified Data.HashMap.Strict              as HM
@@ -58,10 +57,10 @@ interpretCatalog :: Monad m
                  -> NodeName
                  -> Facts
                  -> Container Text -- ^ Server settings
-                 -> m (Pair (S.Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))  [Pair Priority Doc])
+                 -> m (Pair (Either PrettyError (FinalCatalog, EdgeMap, FinalCatalog, [Resource]))  [Pair Priority Doc])
 interpretCatalog interpretReader node facts settings = do
     (output, _, warnings) <- interpretMonad interpretReader (initialState facts settings) (computeCatalog node)
-    return (strictifyEither output :!: warnings)
+    pure (output :!: warnings)
 
 isParent :: Text -> CurContainerDesc -> InterpreterMonad Bool
 isParent cur (ContClass possibleparent) = preuse (scopes . ix cur . scopeParent) >>= \case

--- a/Puppet/Utils.hs
+++ b/Puppet/Utils.hs
@@ -5,6 +5,7 @@
 module Puppet.Utils (
       textElem
     , getDirectoryContents
+    , ifM
     , takeBaseName
     , takeDirectory
     , strictifyEither
@@ -154,3 +155,6 @@ checkForSubFiles extension dir =
 
 getDirContents :: T.Text -> IO [T.Text]
 getDirContents x = fmap (filter (not . T.all (=='.'))) (getDirectoryContents x)
+
+ifM :: Monad m => m Bool -> m a -> m a -> m a
+ifM p x y = p >>= \b -> if b then x else y

--- a/progs/yera.hs
+++ b/progs/yera.hs
@@ -50,7 +50,7 @@ configInfo = info (configParser <**> helper) mempty
 main :: IO ()
 main = do
   Config fp query qtype vars <- execParser configInfo
-  hiera <- startHiera' fp
+  hiera <- startHiera fp
   hiera (HM.fromList vars) (T.pack query) qtype >>= \case
     S.Left rr -> error (show rr)
     S.Right Nothing -> putStrLn "no match" >> exitFailure

--- a/progs/yera.hs
+++ b/progs/yera.hs
@@ -1,11 +1,13 @@
+{-# LANGUAGE LambdaCase #-}
 module Main (main) where
-  
+
 import           Options.Applicative
 import           Data.Monoid
 import qualified Data.Text as T
 import qualified Data.Either.Strict as S
 import qualified Data.HashMap.Strict as HM
 import           Text.PrettyPrint.ANSI.Leijen (pretty)
+import System.Exit
 
 import Puppet.Interpreter.Types
 import Puppet.Interpreter.PrettyPrinter()
@@ -48,12 +50,8 @@ configInfo = info (configParser <**> helper) mempty
 main :: IO ()
 main = do
   Config fp query qtype vars <- execParser configInfo
-  ehiera <- startHiera fp
-  case ehiera of
-    Left rr -> error rr
-    Right hiera -> do
-      r <- hiera (HM.fromList vars) (T.pack query) qtype
-      case r of
-        S.Left rr -> error (show rr)
-        S.Right Nothing -> putStrLn "no match"
-        S.Right (Just res) -> print (pretty res)
+  hiera <- startHiera' fp
+  hiera (HM.fromList vars) (T.pack query) qtype >>= \case
+    S.Left rr -> error (show rr)
+    S.Right Nothing -> putStrLn "no match" >> exitFailure
+    S.Right (Just res) -> print (pretty res)

--- a/tests/hiera.hs
+++ b/tests/hiera.hs
@@ -61,8 +61,8 @@ main = withSystemTempDirectory "hieratest" $ \tmpfp -> do
         pusers = HM.fromList [ ("bob", PHash (HM.singleton "uid" (PNumber 100)))
                              , ("tom" , PHash (HM.singleton "uid" (PNumber 12)))
                              ]
-    Right q3 <- startHiera (tmpfp ++ "/hiera3.yaml")
-    Right q5 <- startHiera (tmpfp ++ "/hiera5.yaml")
+    q3 <- startHiera (tmpfp ++ "/hiera3.yaml")
+    q5 <- startHiera (tmpfp ++ "/hiera5.yaml")
     let checkOutput v (S.Right x) = x @?= v
         checkOutput _ (S.Left rr) = assertFailure (show rr)
     hspec $ do


### PR DESCRIPTION
I don't quite understand why we are returning a dummy hiera in case of a ParseException in startHiera.

The client calls in Daemon.hs would fold the either with `either error (starthiera p)` which seems to defeat the purpose of the either type.

Is it ok to just throw the ParseException (by using `decodeFile` instead of `decodeFileEither`) and let the caller catch the exception when it is suited ?

Thanks for your input.