### PR TITLE
Replace runtime foreign ruby exception with a log.errorM statement

### DIFF
--- a/Puppet/Daemon.hs
+++ b/Puppet/Daemon.hs
@@ -212,6 +212,7 @@ setupLogger :: Log.Priority -> IO ()
 setupLogger p = do
     Log.updateGlobalLogger daemonLoggerName (Log.setLevel p)
     Log.updateGlobalLogger hieraLoggerName (Log.setLevel p)
+    Log.updateGlobalLogger erbLoggerName (Log.setLevel p)
     hs <- consoleLogHandler
     Log.updateGlobalLogger Log.rootLoggerName $ Log.setHandlers [hs]
     where


### PR DESCRIPTION
This is not ideal for two reasons:
- it lacks flexible (enable/disable for some modules)
- it doesn't show any information about the culprit erb file.