### PR TITLE
Replace Data.FileCache with a plain cache with no watch

### DIFF
--- a/language-puppet.cabal
+++ b/language-puppet.cabal
@@ -36,6 +36,7 @@ library
                        , Erb.Ruby
                        , Facter
                        , Hiera.Server
+                       , Cache.File
                        , Puppet.Daemon
                        , PuppetDB.Common
                        , PuppetDB.Dummy
@@ -94,7 +95,6 @@ library
                      , cryptonite           >= 0.6
                      , directory            >= 1.2     && < 1.4
                      , exceptions           >= 0.8     && < 0.9
-                     , filecache            >= 0.2.9   && < 0.3
                      , filepath             >= 1.4
                      , formatting
                      , hashable             == 1.2.*

--- a/src/Cache/File.hs
+++ b/src/Cache/File.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE StrictData #-}
+{- |
+This module let you create caches where keys are file names.
+
+Unlike 'Data.FileCache' is doesn't watch for file change.
+
+It is only useful in a client setting, not in a daemon/server one.
+
+This is usually done in the following fashion :
+
+> cache <- newFileCache
+> o <- query cache "/path/to/file" computation
+
+The computation will be used to populate the cache if this call results in a miss. The result is forced to WHNM.
+-}
+module Cache.File
+  ( FileCache
+  , newFileCache
+  , query
+  ) where
+
+import           Protolude
+
+import           Control.Concurrent.STM
+import           Control.Exception.Lens
+import           Data.HashMap.Strict    (HashMap)
+import qualified Data.HashMap.Strict    as Map
+import           Data.String
+
+-- | The main opaque FileCache type.
+newtype FileCache e a
+  = FileCache (TVar (HashMap FilePath (Either e a)))
+
+-- | Generates a new file cache (smart constructor).
+newFileCache :: IO (FileCache r a)
+newFileCache = FileCache <$> newTVarIO Map.empty
+
+-- | Queries the cache, populating it if necessary.
+--
+-- Queries that fail with an 'IOExeception' will not create a cache entry.
+query :: IsString e
+      => FileCache e a
+      -> FilePath -- ^ Path of the file entry
+      -> IO (Either e a) -- ^ The computation that will be used to populate the cache
+      -> IO (Either e a) -- ^ Return a "Data.Either.Strict"
+query f@(FileCache fc) fp action = do
+  mp <- getCache f
+  case Map.lookup fp mp of
+    Just x -> pure x
+    Nothing -> do
+      a <- catching _IOException action (pure . Left . fromString . show)
+      atomically (modifyTVar fc (Map.insert fp a))
+      pure a
+
+getCache :: FileCache e a -> IO (HashMap FilePath (Either e a))
+getCache (FileCache q) = atomically (readTVar q)

--- a/src/Erb/Parser.hs
+++ b/src/Erb/Parser.hs
@@ -172,10 +172,10 @@ erbparser :: Parser [RubyStatement]
 erbparser = textblock
 
 parseErbFile :: FilePath -> IO (Either ParseError [RubyStatement])
-parseErbFile fname = parseContent `catch` handler
+parseErbFile fname = parseContent `catch` handler0
     where
         parseContent = (runParser erbparser () fname . Text.unpack) `fmap` readFile fname
-        handler e = let msg = show (e :: SomeException)
+        handler0 e = let msg = show (e :: SomeException)
                     in  return $ Left $ newErrorMessage (Message msg) (initialPos fname)
 
 parseErbString :: String -> Either ParseError [RubyStatement]


### PR DESCRIPTION
Watching for file changes it useless in the current client only setting.

If a server settings is set up, it would be nice to change the filecache package
to work with OS X. That would anyway require changing the APIs because the
underline fsnotify package is using a 'withXXX' pattern.