### PR TITLE
Add debian 'Section'

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,5 @@
 Source: language-puppet
+Section: admin
 Maintainer: Simon Marechal <bartavelle@gmail.com>
 Priority: optional
 


### PR DESCRIPTION
"Section" is necessary (in debian/control) to add the debian package into a repository with reprepro (otherwise, you need to specify one using the -S parameter of reprepro) 