### PR TITLE
Replace Control.Monad.Catch.throwM by ExceptT in OptionalTests.

### DIFF
--- a/src/XPrelude/Extra.hs
+++ b/src/XPrelude/Extra.hs
@@ -39,7 +39,7 @@ import           Protolude                         as Exports hiding (Down, Infi
 import           Control.Exception.Lens            as Exports (catching)
 import           Control.Lens                      as Exports hiding (Strict, argument, noneOf, op)
 import           Control.Monad                     as Exports (fail)
-import           Control.Monad.Trans.Except        as Exports (except, throwE)
+import           Control.Monad.Trans.Except        as Exports (except, throwE, catchE)
 import           Control.Monad.Trans.Maybe         as Exports (runMaybeT)
 import           Data.Aeson                        as Exports (FromJSON, ToJSON, fromJSON, toJSON)
 import           Data.HashMap.Strict               as Exports (HashMap)

--- a/src/XPrelude/PP.hs
+++ b/src/XPrelude/PP.hs
@@ -4,7 +4,6 @@
 module XPrelude.PP (
   module Exports
   , PrettyError (..)
-  , _PrettyError
   , prettyToShow
   , ppline
   , pplines
@@ -15,7 +14,6 @@ where
 
 import           Protolude
 
-import           Control.Lens
 import           Data.Scientific
 import           Data.String
 import qualified Data.Text                    as Text
@@ -31,17 +29,12 @@ newtype PrettyError = PrettyError
   { getError :: Doc
   } deriving Show
 
-_PrettyError :: Prism' SomeException PrettyError
-_PrettyError = prism' toException fromException
-
 instance Monoid PrettyError where
   mempty = PrettyError mempty
-  mappend a b = PrettyError $ getError a <+> getError b
+  mappend a b = PrettyError $ align (vsep [getError a, getError b])
 
 instance IsString PrettyError where
   fromString = PrettyError . string
-
-instance Exception PrettyError
 
 instance Pretty PrettyError where
   pretty = getError


### PR DESCRIPTION
With this change, multiple errors in testFileSources will be displayed.
It might also be more logical to use ExceptT in such situation.