### PR TITLE
Implement the mock translate function (from Puppetlabs-translate)

### DIFF
--- a/src/Puppet/Runner/Stdlib.hs
+++ b/src/Puppet/Runner/Stdlib.hs
@@ -118,6 +118,8 @@ stdlibFunctions = HM.fromList [ singleArgument "abs" puppetAbs
                               -- type
                               -- union
                               , singleArgument "unique" unique
+                              -- from puppetlabs-translate
+                              , ("translate", translate)
                               -- unix2dos
                               , ("upcase", stringArrayFunction Text.toUpper)
                               -- uriescape
@@ -526,3 +528,8 @@ validateInteger x = PUndef <$ mapM_ vb x
 pvalues :: PValue -> InterpreterMonad PValue
 pvalues (PHash h) = return $ PArray (toVectorOf traverse h)
 pvalues x         = throwPosError ("values(): expected a hash, not" <+> pretty x)
+
+-- dummy translate method from puppetlabs-translate (used in puppetlabs-docker for instance)
+translate :: [PValue] -> InterpreterMonad PValue
+translate [v@(PString _)] = pure v
+translate x = throwPosError ("values(): expected a String, not" <+> pretty x)


### PR DESCRIPTION
I was about to push this PR but it does not accept the the following syntax with the double `((`. 

Any idea ?

```
 fail translate(('log_level must be one of debug, info, warn, error or fatal'))
```
https://github.com/puppetlabs/puppetlabs-docker/blob/master/manifests/init.pp#L498
                                                                                                                                                                                                                 
```
ERROR: (swarm.manager.dev) cannot parse ./modules/application/manifests/role/swarm/test.pp:3:17:
  |
3 |   fail translate(('You must provide the $bridge parameter.'))
  |                 ^
unexpected '('
expecting ',', '}', operator, or the rest of Statement
 at ./modules/application/manifests/role/swarm/manager.pp:2:3
```
