### PR TITLE
Enable usage of http/https in file source parameter

### DIFF
--- a/src/Puppet/Language/NativeTypes/File.hs
+++ b/src/Puppet/Language/NativeTypes/File.hs
@@ -68,8 +68,8 @@ numeric modestr = do
                  else identity
 
 checkSource :: Text -> PValue -> NativeTypeValidate
-checkSource _ (PString x) res | any (`Text.isPrefixOf` x) ["puppet://", "file://", "/"] = Right res
-                              | otherwise = throwError "A source should start with either puppet:// or file:// or an absolute path"
+checkSource _ (PString x) res | any (`Text.isPrefixOf` x) ["puppet://", "file://", "/", "http://", "https://"] = Right res
+                              | otherwise = throwError "A source should start with either puppet://, http://, https:// or file:// or an absolute path"
 checkSource _ x _ = throwError $ PrettyError ("Expected a string, not" <+> pretty x)
 
 data PermParts = Special | User | Group | Other


### PR DESCRIPTION
Puppet 4 can install a file from an URL starting with https or http (cf
https://tickets.puppetlabs.com/browse/PUP-1072)